### PR TITLE
Ensure tests run without jsdom environment

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,13 @@ function changeColor(idname) {
 }
 
 function reloadButton() {
-  window.location.reload();
+  if (
+    typeof window !== 'undefined' &&
+    window.location &&
+    typeof window.location.reload === 'function'
+  ) {
+    window.location.reload();
+  }
 }
 
 if (typeof window !== 'undefined') {

--- a/app.test.js
+++ b/app.test.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 const { changeColor, reloadButton } = require('./app');
 
 describe('changeColor', () => {
@@ -18,8 +15,7 @@ describe('changeColor', () => {
 describe('reloadButton', () => {
   test('calls window.location.reload', () => {
     const reloadMock = jest.fn();
-    delete window.location;
-    window.location = { reload: reloadMock };
+    global.window = { location: { reload: reloadMock } };
     reloadButton();
     expect(reloadMock).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Guard `reloadButton` against missing `window`
- Simplify tests by mocking `window` instead of relying on `jest-environment-jsdom`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689605567f90832c9a264914972ece65